### PR TITLE
Add fix for showing multiple StarRatings on the same page

### DIFF
--- a/src/star-ratings.js
+++ b/src/star-ratings.js
@@ -69,7 +69,7 @@ class StarRatings extends React.Component {
   }
 
   get fillId() {
-    // Using the rating's decimal place to set a unique id for the fill. e.g. a rating of 3.5 and 4.5 will use the same half fill star.
+    // Using the rating's decimal place to set a unique id for the fill. e.g. a rating of 3.5 and 4.5 will use the same half fill star with id #star-grad-5.
     return `star-grad-${Math.round((this.props.rating % 1) * 10)}${
       this.props.name ? `-${this.props.name}` : ""
     }`;

--- a/src/star-ratings.js
+++ b/src/star-ratings.js
@@ -69,9 +69,9 @@ class StarRatings extends React.Component {
   }
 
   get fillId() {
-    return `star-grad-${this.props.numberOfStars}${
-      this.props.name ? `-${this.props.name}` : ""
-    }`;
+    return `star-grad-${this.props.numberOfStars}-${Math.round(
+      (this.props.rating % 1) * 10
+    )}${this.props.name ? `-${this.props.name}` : ""}`;
   }
 
   hoverOverStar = starRating => {

--- a/src/star-ratings.js
+++ b/src/star-ratings.js
@@ -69,9 +69,10 @@ class StarRatings extends React.Component {
   }
 
   get fillId() {
-    return `star-grad-${this.props.numberOfStars}-${Math.round(
-      (this.props.rating % 1) * 10
-    )}${this.props.name ? `-${this.props.name}` : ""}`;
+    // Using the rating's decimal place to set a unique id for the fill. e.g. a rating of 3.5 and 4.5 will use the same half fill star.
+    return `star-grad-${Math.round((this.props.rating % 1) * 10)}${
+      this.props.name ? `-${this.props.name}` : ""
+    }`;
   }
 
   hoverOverStar = starRating => {


### PR DESCRIPTION
- Append number referencing the decimal place of the partial start to fillId so that multiple StarReview components don't conflict with each other. 