### PR TITLE
Add a UUID to the generated `fillId`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "classnames": "^2.2.1",
     "prop-types": "^15.6.0",
-    "react": "^17.0.1"
+    "react": "^17.0.1",
+    "uuid": "^9.0.0"
   }
 }

--- a/src/star-ratings.js
+++ b/src/star-ratings.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { v4 as uuidv4 } from "uuid";
 import Star from "./star";
 
 class StarRatings extends React.Component {
@@ -78,9 +79,7 @@ class StarRatings extends React.Component {
 
   get fillId() {
     // Using the rating's decimal place to set a unique id for the fill. e.g. a rating of 3.5 and 4.5 will use the same half fill star with id #star-grad-5.
-    return `star-grad-${Math.round((this.props.rating % 1) * 10)}${
-      this.props.name ? `-${this.props.name}` : ""
-    }`;
+    return `star-grad-${Math.round((this.props.rating % 1) * 10)}-${uuidv4()}`;
   }
 
   hoverOverStar = (starRating) => {


### PR DESCRIPTION
We had issues with duplicate `fillId` values for the star gradients.

If multiple `StarRating` components were being used with different colors, there would be multiple gradient HTML elements with the same name but different fill colors (see example bug ticket [here](https://dealdotcom.atlassian.net/browse/CWEB-795)). 

This PR adds a unique ID to the generated `fillId`, which means each HTML element has a unique ID.